### PR TITLE
Fixed Signal Strength Indicator

### DIFF
--- a/myHotTub/Views/ControlsView/SignalStrenghButton/SignalStrengthButton.swift
+++ b/myHotTub/Views/ControlsView/SignalStrenghButton/SignalStrengthButton.swift
@@ -9,12 +9,12 @@ struct SignalStrengthButton: View {
 			return ("arrow.clockwise", 0)
 		}
 		
-		switch (contentManager.other.rssi) {
-		case ..<(79): return ("cellularbars", 0.25)
-		case -80..<(-71): return ("cellularbars", 0.50)
-		case -70..<(-61): return ("cellularbars", 0.75)
-		case (-60)...: return ("cellularbars", 0.75)
-		default: return ("arrow.clockwise", 0)
+		switch contentManager.other.rssi {
+		case ..<(-81):        return ("cellularbars", 0.25)  // Poor signal
+		case -81..<(-71):     return ("cellularbars", 0.50)  // Fair signal
+		case -71..<(-61):     return ("cellularbars", 0.75)  // Good signal
+		case (-61)...:        return ("cellularbars", 1.0)   // Excellent signal
+		default:              return ("arrow.clockwise", 0)
 		}
 	}
 	


### PR DESCRIPTION
Fixed the Signal Strength indicator displayed on the Control Screen. This now accurately represents the actual Signal Strength reported by the ESP8266 module.